### PR TITLE
Discuss sanity structure

### DIFF
--- a/actions/PreviewAction.js
+++ b/actions/PreviewAction.js
@@ -1,7 +1,12 @@
 import React from 'react';
 
 export const PreviewAction = (props) => {
-  const { published, draft } = props;
+  const { published, draft, type } = props;
+  
+  // Only show for content types
+  if (!['shorts', 'longForm'].includes(type)) {
+    return null;
+  }
   
   // Use published document if available, otherwise use draft
   const document = published || draft;
@@ -10,14 +15,8 @@ export const PreviewAction = (props) => {
     return null; // Don't show action if no document
   }
   
-  const { _type, _id } = document;
-  
-  // Only show for content types
-  if (!['shorts', 'longForm'].includes(_type)) {
-    return null;
-  }
-  
-  const previewUrl = `https://finishlineathlete.com/preview/${_type}/${_id}?secret=preview-secret-2024`;
+  const { _id } = document;
+  const previewUrl = `https://finishlineathlete.com/preview/${type}/${_id}?secret=preview-secret-2024`;
   
   return {
     label: '👁️ Preview',

--- a/actions/PreviewAction.js
+++ b/actions/PreviewAction.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export const PreviewAction = (props) => {
+  const { published, draft } = props;
+  
+  // Use published document if available, otherwise use draft
+  const document = published || draft;
+  
+  if (!document) {
+    return null; // Don't show action if no document
+  }
+  
+  const { _type, _id } = document;
+  
+  // Only show for content types
+  if (!['shorts', 'longForm'].includes(_type)) {
+    return null;
+  }
+  
+  const previewUrl = `https://finishlineathlete.com/preview/${_type}/${_id}?secret=preview-secret-2024`;
+  
+  return {
+    label: '👁️ Preview',
+    onHandle: () => {
+      window.open(previewUrl, '_blank');
+      props.onComplete();
+    },
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6504,6 +6504,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -10124,6 +10136,12 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -11761,6 +11779,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -12751,12 +12781,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -12962,6 +12992,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -13218,9 +13254,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
       "license": "MIT"
     },
     "node_modules/react-refractor": {
@@ -13493,6 +13529,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -14143,12 +14191,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/sanity/node_modules/react-is": {
-      "version": "19.1.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
-      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
-      "license": "MIT"
     },
     "node_modules/sanity/node_modules/resolve-from": {
       "version": "5.0.0",
@@ -15165,18 +15207,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tldts": {
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
@@ -15454,7 +15484,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15916,18 +15946,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vite/node_modules/postcss": {

--- a/preview-backend-examples.md
+++ b/preview-backend-examples.md
@@ -1,0 +1,469 @@
+# Preview Backend Implementation Examples
+
+## Frontend Requirements for finishlineathlete.com
+
+You need to add **ONE new route** to your frontend to handle previews:
+
+### Route Structure
+```
+https://finishlineathlete.com/preview/[contentType]/[documentId]?secret=[secret]
+```
+
+Examples:
+- `https://finishlineathlete.com/preview/shorts/abc123?secret=preview-secret-2024`
+- `https://finishlineathlete.com/preview/longForm/def456?secret=preview-secret-2024`
+
+## Implementation Examples
+
+### 1. Next.js Implementation
+
+Create file: `pages/preview/[type]/[id].js`
+
+```javascript
+import {getClient} from '../lib/sanity'
+import fs from 'fs'
+import path from 'path'
+
+const PREVIEW_SECRET = 'preview-secret-2024' // Use environment variable in production
+
+export default function PreviewPage({data, contentType, error}) {
+  if (error) {
+    return (
+      <div style={{padding: '20px', textAlign: 'center'}}>
+        <h1>Preview Not Available</h1>
+        <p>{error}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div dangerouslySetInnerHTML={{__html: renderPreviewHTML(data, contentType)}} />
+  )
+}
+
+export async function getServerSideProps(context) {
+  const {type, id} = context.params
+  const {secret} = context.query
+  
+  // Validate secret
+  if (secret !== PREVIEW_SECRET) {
+    return {
+      props: {
+        error: 'Invalid preview secret',
+        data: null,
+        contentType: type
+      }
+    }
+  }
+
+  try {
+    // Fetch document from Sanity
+    const client = getClient()
+    const data = await client.getDocument(id)
+    
+    if (!data) {
+      return {
+        props: {
+          error: 'Document not found',
+          data: null,
+          contentType: type
+        }
+      }
+    }
+
+    return {
+      props: {
+        data,
+        contentType: type,
+        error: null
+      }
+    }
+  } catch (error) {
+    return {
+      props: {
+        error: 'Failed to load preview',
+        data: null,
+        contentType: type
+      }
+    }
+  }
+}
+
+function renderPreviewHTML(data, contentType) {
+  // Load the HTML template
+  const templatePath = path.join(process.cwd(), 'preview-template.html')
+  const template = fs.readFileSync(templatePath, 'utf8')
+  
+  // Replace placeholders with actual data
+  return template
+    .replace('{{previewData}}', JSON.stringify(data))
+    .replace('{{contentType}}', contentType)
+    .replace('{{title}}', data.title || 'Untitled')
+}
+```
+
+### 2. React/Vite Implementation
+
+Create file: `src/pages/Preview.jsx`
+
+```javascript
+import {useParams, useSearchParams} from 'react-router-dom'
+import {useEffect, useState} from 'react'
+import {client} from '../lib/sanity'
+
+const PREVIEW_SECRET = 'preview-secret-2024'
+
+export default function PreviewPage() {
+  const {type, id} = useParams()
+  const [searchParams] = useSearchParams()
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const secret = searchParams.get('secret')
+    
+    if (secret !== PREVIEW_SECRET) {
+      setError('Invalid preview secret')
+      setLoading(false)
+      return
+    }
+
+    async function fetchPreview() {
+      try {
+        const document = await client.getDocument(id)
+        if (!document) {
+          setError('Document not found')
+        } else {
+          setData(document)
+        }
+      } catch (err) {
+        setError('Failed to load preview')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchPreview()
+  }, [id, searchParams])
+
+  if (loading) {
+    return <div>Loading preview...</div>
+  }
+
+  if (error) {
+    return <div>Error: {error}</div>
+  }
+
+  return (
+    <div>
+      <div style={{
+        background: '#ff6b35',
+        color: 'white',
+        padding: '12px 20px',
+        textAlign: 'center',
+        fontWeight: 'bold'
+      }}>
+        🚧 PREVIEW MODE - This content is not yet published
+      </div>
+      
+      <div style={{maxWidth: '1200px', margin: '0 auto', padding: '20px'}}>
+        {type === 'shorts' && <ShortsPreview data={data} />}
+        {type === 'longForm' && <LongFormPreview data={data} />}
+      </div>
+    </div>
+  )
+}
+
+function ShortsPreview({data}) {
+  return (
+    <article>
+      <header style={{
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        color: 'white',
+        padding: '60px 40px',
+        textAlign: 'center'
+      }}>
+        {data.featuredImage && (
+          <img 
+            src={data.featuredImage.asset.url} 
+            alt={data.title}
+            style={{
+              width: '100%',
+              maxWidth: '800px',
+              height: '400px',
+              objectFit: 'cover',
+              borderRadius: '8px',
+              marginBottom: '30px'
+            }}
+          />
+        )}
+        <h1 style={{fontSize: '2.5rem', marginBottom: '20px'}}>
+          {data.title || 'Untitled'}
+        </h1>
+        <p style={{fontSize: '1.2rem', marginBottom: '30px'}}>
+          {data.excerpt || ''}
+        </p>
+        <div style={{display: 'flex', justifyContent: 'center', gap: '30px'}}>
+          <span>👤 By {data.author?.name || 'Unknown Author'}</span>
+          <span>📅 {new Date(data.publishDate).toLocaleDateString()}</span>
+          <span>⏱️ {data.readingTime || 0} min read</span>
+        </div>
+      </header>
+      
+      <div style={{padding: '40px', lineHeight: '1.8'}}>
+        <p>{data.body || ''}</p>
+      </div>
+      
+      {data.tags && data.tags.length > 0 && (
+        <div style={{padding: '0 40px 40px', display: 'flex', flexWrap: 'wrap', gap: '10px'}}>
+          {data.tags.map((tag, index) => (
+            <span key={index} style={{
+              background: '#f0f0f0',
+              color: '#333',
+              padding: '6px 12px',
+              borderRadius: '20px',
+              fontSize: '0.9rem'
+            }}>
+              #{tag.title || tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  )
+}
+
+function LongFormPreview({data}) {
+  return (
+    <article>
+      <header style={{
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        color: 'white',
+        padding: '60px 40px',
+        textAlign: 'center'
+      }}>
+        {data.featuredImage && (
+          <img 
+            src={data.featuredImage.asset.url} 
+            alt={data.title}
+            style={{
+              width: '100%',
+              maxWidth: '800px',
+              height: '400px',
+              objectFit: 'cover',
+              borderRadius: '8px',
+              marginBottom: '30px'
+            }}
+          />
+        )}
+        <h1 style={{fontSize: '2.5rem', marginBottom: '20px'}}>
+          {data.title || 'Untitled'}
+        </h1>
+        <p style={{fontSize: '1.2rem', marginBottom: '20px'}}>
+          {data.excerpt || ''}
+        </p>
+        {data.cardSummary && (
+          <p style={{fontSize: '1.1rem', marginBottom: '30px', fontStyle: 'italic'}}>
+            {data.cardSummary}
+          </p>
+        )}
+        <div style={{display: 'flex', justifyContent: 'center', gap: '30px'}}>
+          <span>👤 By {data.author?.name || 'Unknown Author'}</span>
+          <span>📅 {new Date(data.publishDate).toLocaleDateString()}</span>
+          <span>⏱️ {data.readingTime || 0} min read</span>
+          <span>📊 {data.wordCount || 0} words</span>
+        </div>
+      </header>
+      
+      <div style={{padding: '40px', lineHeight: '1.8'}}>
+        <p>{data.body || ''}</p>
+      </div>
+      
+      {data.tags && data.tags.length > 0 && (
+        <div style={{padding: '0 40px 40px', display: 'flex', flexWrap: 'wrap', gap: '10px'}}>
+          {data.tags.map((tag, index) => (
+            <span key={index} style={{
+              background: '#f0f0f0',
+              color: '#333',
+              padding: '6px 12px',
+              borderRadius: '20px',
+              fontSize: '0.9rem'
+            }}>
+              #{tag.title || tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </article>
+  )
+}
+```
+
+### 3. Vanilla JavaScript Implementation
+
+Create file: `preview.html`
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Preview | Finish Line Athlete</title>
+    <script src="https://unpkg.com/@sanity/client@latest/dist/index.js"></script>
+</head>
+<body>
+    <div id="preview-container">
+        <div id="loading">Loading preview...</div>
+        <div id="error" style="display: none;">Preview not available</div>
+        <div id="content" style="display: none;"></div>
+    </div>
+
+    <script>
+        const PREVIEW_SECRET = 'preview-secret-2024'
+        
+        // Initialize Sanity client
+        const client = sanityClient({
+            projectId: 'ouvbyhmf',
+            dataset: 'production',
+            useCdn: false, // Always fetch fresh data for previews
+            apiVersion: '2024-01-01'
+        })
+
+        async function loadPreview() {
+            const urlParams = new URLSearchParams(window.location.search)
+            const secret = urlParams.get('secret')
+            const pathParts = window.location.pathname.split('/')
+            const contentType = pathParts[2] // preview/[type]/[id]
+            const documentId = pathParts[3]
+
+            if (secret !== PREVIEW_SECRET) {
+                showError('Invalid preview secret')
+                return
+            }
+
+            try {
+                const data = await client.getDocument(documentId)
+                if (!data) {
+                    showError('Document not found')
+                    return
+                }
+
+                renderPreview(data, contentType)
+            } catch (error) {
+                showError('Failed to load preview')
+                console.error(error)
+            }
+        }
+
+        function showError(message) {
+            document.getElementById('loading').style.display = 'none'
+            document.getElementById('error').textContent = message
+            document.getElementById('error').style.display = 'block'
+        }
+
+        function renderPreview(data, contentType) {
+            const content = document.getElementById('content')
+            
+            if (contentType === 'shorts') {
+                content.innerHTML = renderShortsPreview(data)
+            } else if (contentType === 'longForm') {
+                content.innerHTML = renderLongFormPreview(data)
+            }
+
+            document.getElementById('loading').style.display = 'none'
+            content.style.display = 'block'
+        }
+
+        function renderShortsPreview(data) {
+            return `
+                <div style="background: #ff6b35; color: white; padding: 12px; text-align: center; font-weight: bold;">
+                    🚧 PREVIEW MODE - This content is not yet published
+                </div>
+                <article style="max-width: 1200px; margin: 0 auto; padding: 20px;">
+                    <header style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 60px 40px; text-align: center; border-radius: 8px;">
+                        ${data.featuredImage ? `<img src="${data.featuredImage.asset.url}" alt="${data.title}" style="width: 100%; max-width: 800px; height: 400px; object-fit: cover; border-radius: 8px; margin-bottom: 30px;">` : ''}
+                        <h1 style="font-size: 2.5rem; margin-bottom: 20px;">${data.title || 'Untitled'}</h1>
+                        <p style="font-size: 1.2rem; margin-bottom: 30px;">${data.excerpt || ''}</p>
+                        <div style="display: flex; justify-content: center; gap: 30px; flex-wrap: wrap;">
+                            <span>👤 By ${data.author?.name || 'Unknown Author'}</span>
+                            <span>📅 ${new Date(data.publishDate).toLocaleDateString()}</span>
+                            <span>⏱️ ${data.readingTime || 0} min read</span>
+                        </div>
+                    </header>
+                    <div style="padding: 40px; line-height: 1.8; font-size: 1.1rem;">
+                        <p>${data.body || ''}</p>
+                    </div>
+                    ${data.tags && data.tags.length > 0 ? `
+                        <div style="padding: 0 40px 40px; display: flex; flex-wrap: wrap; gap: 10px;">
+                            ${data.tags.map(tag => `<span style="background: #f0f0f0; color: #333; padding: 6px 12px; border-radius: 20px; font-size: 0.9rem;">#${tag.title || tag}</span>`).join('')}
+                        </div>
+                    ` : ''}
+                </article>
+            `
+        }
+
+        function renderLongFormPreview(data) {
+            return `
+                <div style="background: #ff6b35; color: white; padding: 12px; text-align: center; font-weight: bold;">
+                    🚧 PREVIEW MODE - This content is not yet published
+                </div>
+                <article style="max-width: 1200px; margin: 0 auto; padding: 20px;">
+                    <header style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 60px 40px; text-align: center; border-radius: 8px;">
+                        ${data.featuredImage ? `<img src="${data.featuredImage.asset.url}" alt="${data.title}" style="width: 100%; max-width: 800px; height: 400px; object-fit: cover; border-radius: 8px; margin-bottom: 30px;">` : ''}
+                        <h1 style="font-size: 2.5rem; margin-bottom: 20px;">${data.title || 'Untitled'}</h1>
+                        <p style="font-size: 1.2rem; margin-bottom: 20px;">${data.excerpt || ''}</p>
+                        ${data.cardSummary ? `<p style="font-size: 1.1rem; margin-bottom: 30px; font-style: italic;">${data.cardSummary}</p>` : ''}
+                        <div style="display: flex; justify-content: center; gap: 30px; flex-wrap: wrap;">
+                            <span>👤 By ${data.author?.name || 'Unknown Author'}</span>
+                            <span>📅 ${new Date(data.publishDate).toLocaleDateString()}</span>
+                            <span>⏱️ ${data.readingTime || 0} min read</span>
+                            <span>📊 ${data.wordCount || 0} words</span>
+                        </div>
+                    </header>
+                    <div style="padding: 40px; line-height: 1.8; font-size: 1.1rem;">
+                        <p>${data.body || ''}</p>
+                    </div>
+                    ${data.tags && data.tags.length > 0 ? `
+                        <div style="padding: 0 40px 40px; display: flex; flex-wrap: wrap; gap: 10px;">
+                            ${data.tags.map(tag => `<span style="background: #f0f0f0; color: #333; padding: 6px 12px; border-radius: 20px; font-size: 0.9rem;">#${tag.title || tag}</span>`).join('')}
+                        </div>
+                    ` : ''}
+                </article>
+            `
+        }
+
+        // Load preview when page loads
+        loadPreview()
+    </script>
+</body>
+</html>
+```
+
+## Environment Variables
+
+Add to your `.env` file:
+
+```bash
+SANITY_PREVIEW_SECRET=preview-secret-2024
+SANITY_PROJECT_ID=ouvbyhmf
+SANITY_DATASET=production
+```
+
+## Security Notes
+
+1. **Change the preview secret** to something secure
+2. **Use environment variables** for secrets
+3. **Add rate limiting** to prevent abuse
+4. **Consider IP whitelisting** for preview access
+5. **Add expiration** to preview links (optional)
+
+## Testing
+
+1. Start your Sanity Studio: `npm run dev`
+2. Open a document (shorts or longForm)
+3. Click the "👁️ Preview" button
+4. Verify the preview opens correctly
+5. Test with different content types and field combinations

--- a/preview-template.html
+++ b/preview-template.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Preview: {{title}} | Finish Line Athlete</title>
+    <style>
+        /* Preview Banner */
+        .preview-banner {
+            background: #ff6b35;
+            color: white;
+            padding: 12px 20px;
+            text-align: center;
+            font-weight: bold;
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+        }
+        
+        /* Preview Container */
+        .preview-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        }
+        
+        /* Content Preview */
+        .content-preview {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+            overflow: hidden;
+        }
+        
+        /* Hero Section */
+        .hero {
+            position: relative;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 60px 40px;
+            text-align: center;
+        }
+        
+        .hero-image {
+            width: 100%;
+            max-width: 800px;
+            height: 400px;
+            object-fit: cover;
+            border-radius: 8px;
+            margin-bottom: 30px;
+        }
+        
+        .hero h1 {
+            font-size: 2.5rem;
+            margin-bottom: 20px;
+            line-height: 1.2;
+        }
+        
+        .excerpt {
+            font-size: 1.2rem;
+            margin-bottom: 30px;
+            opacity: 0.9;
+            line-height: 1.6;
+        }
+        
+        .card-summary {
+            font-size: 1.1rem;
+            margin-bottom: 30px;
+            opacity: 0.8;
+            font-style: italic;
+        }
+        
+        .meta {
+            display: flex;
+            justify-content: center;
+            gap: 30px;
+            flex-wrap: wrap;
+            font-size: 0.9rem;
+            opacity: 0.8;
+        }
+        
+        .meta span {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        
+        /* Content Body */
+        .content-body {
+            padding: 40px;
+            line-height: 1.8;
+            font-size: 1.1rem;
+        }
+        
+        .content-body p {
+            margin-bottom: 20px;
+        }
+        
+        /* Tags */
+        .tags {
+            padding: 0 40px 40px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        
+        .tag {
+            background: #f0f0f0;
+            color: #333;
+            padding: 6px 12px;
+            border-radius: 20px;
+            font-size: 0.9rem;
+            text-decoration: none;
+        }
+        
+        /* SEO Preview Section */
+        .seo-preview {
+            background: #f8f9fa;
+            border-top: 1px solid #e9ecef;
+            padding: 30px 40px;
+        }
+        
+        .seo-preview h3 {
+            color: #333;
+            margin-bottom: 20px;
+            font-size: 1.3rem;
+        }
+        
+        .seo-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+        }
+        
+        .seo-field {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            border-left: 4px solid #007bff;
+        }
+        
+        .seo-field strong {
+            display: block;
+            color: #007bff;
+            margin-bottom: 5px;
+            font-size: 0.9rem;
+        }
+        
+        .seo-field span {
+            color: #333;
+            font-size: 0.95rem;
+        }
+        
+        /* Responsive Design */
+        @media (max-width: 768px) {
+            .preview-container {
+                padding: 10px;
+            }
+            
+            .hero {
+                padding: 40px 20px;
+            }
+            
+            .hero h1 {
+                font-size: 2rem;
+            }
+            
+            .content-body {
+                padding: 20px;
+            }
+            
+            .seo-preview {
+                padding: 20px;
+            }
+            
+            .meta {
+                flex-direction: column;
+                gap: 15px;
+            }
+        }
+        
+        /* Loading State */
+        .loading {
+            text-align: center;
+            padding: 60px;
+            color: #666;
+        }
+        
+        .error {
+            background: #f8d7da;
+            color: #721c24;
+            padding: 20px;
+            border-radius: 6px;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <!-- Preview Banner -->
+    <div class="preview-banner">
+        🚧 PREVIEW MODE - This content is not yet published
+    </div>
+
+    <div class="preview-container">
+        <div id="loading" class="loading">
+            Loading preview...
+        </div>
+        
+        <div id="error" class="error" style="display: none;">
+            Preview not available. Please check the URL and try again.
+        </div>
+        
+        <div id="preview-content" style="display: none;">
+            <!-- Content will be dynamically loaded here -->
+        </div>
+    </div>
+
+    <script>
+        // Preview data will be injected here by your backend
+        const previewData = {{previewData}};
+        const contentType = '{{contentType}}';
+        
+        function renderPreview() {
+            if (!previewData) {
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('error').style.display = 'block';
+                return;
+            }
+            
+            const content = previewData;
+            const previewContent = document.getElementById('preview-content');
+            
+            // Render based on content type
+            if (contentType === 'shorts') {
+                previewContent.innerHTML = renderShortsPreview(content);
+            } else if (contentType === 'longForm') {
+                previewContent.innerHTML = renderLongFormPreview(content);
+            }
+            
+            document.getElementById('loading').style.display = 'none';
+            previewContent.style.display = 'block';
+        }
+        
+        function renderShortsPreview(content) {
+            return `
+                <article class="content-preview">
+                    <header class="hero">
+                        ${content.featuredImage ? `<img src="${content.featuredImage.asset.url}" alt="${content.title}" class="hero-image">` : ''}
+                        <h1>${content.title || 'Untitled'}</h1>
+                        <p class="excerpt">${content.excerpt || ''}</p>
+                        <div class="meta">
+                            <span>👤 By ${content.author?.name || 'Unknown Author'}</span>
+                            <span>📅 ${formatDate(content.publishDate)}</span>
+                            <span>⏱️ ${content.readingTime || 0} min read</span>
+                            <span>📊 ${content.wordCount || 0} words</span>
+                        </div>
+                    </header>
+                    
+                    <div class="content-body">
+                        <p>${content.body || ''}</p>
+                    </div>
+                    
+                    ${content.tags && content.tags.length > 0 ? `
+                        <div class="tags">
+                            ${content.tags.map(tag => `<span class="tag">#${tag.title || tag}</span>`).join('')}
+                        </div>
+                    ` : ''}
+                    
+                    <div class="seo-preview">
+                        <h3>SEO Preview</h3>
+                        <div class="seo-meta">
+                            <div class="seo-field">
+                                <strong>Title Tag</strong>
+                                <span>${content.titleTag || content.title || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Meta Description</strong>
+                                <span>${content.metaDescription || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Focus Keyword</strong>
+                                <span>${content.focusKeyword || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Primary Keyword</strong>
+                                <span>${content.primaryKeyword || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Content Type</strong>
+                                <span>${content.contentType || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Primary Topic/Category</strong>
+                                <span>${content.primaryTopicCategory || 'Not set'}</span>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            `;
+        }
+        
+        function renderLongFormPreview(content) {
+            return `
+                <article class="content-preview long-form">
+                    <header class="hero">
+                        ${content.featuredImage ? `<img src="${content.featuredImage.asset.url}" alt="${content.title}" class="hero-image">` : ''}
+                        <h1>${content.title || 'Untitled'}</h1>
+                        <p class="excerpt">${content.excerpt || ''}</p>
+                        ${content.cardSummary ? `<p class="card-summary">${content.cardSummary}</p>` : ''}
+                        <div class="meta">
+                            <span>👤 By ${content.author?.name || 'Unknown Author'}</span>
+                            <span>📅 ${formatDate(content.publishDate)}</span>
+                            <span>⏱️ ${content.readingTime || 0} min read</span>
+                            <span>📊 ${content.wordCount || 0} words</span>
+                        </div>
+                    </header>
+                    
+                    <div class="content-body">
+                        <p>${content.body || ''}</p>
+                    </div>
+                    
+                    ${content.tags && content.tags.length > 0 ? `
+                        <div class="tags">
+                            ${content.tags.map(tag => `<span class="tag">#${tag.title || tag}</span>`).join('')}
+                        </div>
+                    ` : ''}
+                    
+                    <div class="seo-preview">
+                        <h3>SEO Preview</h3>
+                        <div class="seo-meta">
+                            <div class="seo-field">
+                                <strong>Title Tag</strong>
+                                <span>${content.titleTag || content.title || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Meta Description</strong>
+                                <span>${content.metaDescription || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Focus Keyword</strong>
+                                <span>${content.focusKeyword || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Primary Keyword</strong>
+                                <span>${content.primaryKeyword || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Content Type</strong>
+                                <span>${content.contentType || 'Not set'}</span>
+                            </div>
+                            <div class="seo-field">
+                                <strong>Primary Topic/Category</strong>
+                                <span>${content.primaryTopicCategory || 'Not set'}</span>
+                            </div>
+                        </div>
+                    </div>
+                </article>
+            `;
+        }
+        
+        function formatDate(dateString) {
+            if (!dateString) return 'Not set';
+            const date = new Date(dateString);
+            return date.toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+            });
+        }
+        
+        // Initialize preview when page loads
+        document.addEventListener('DOMContentLoaded', renderPreview);
+    </script>
+</body>
+</html>

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -16,30 +16,31 @@ export default defineConfig({
     types: schemaTypes,
   },
 
-  document: {
-    actions: (prev, context) => {
-      // Add preview action for content types
-      if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
-        return [
-          ...prev,
-          {
-            title: 'Preview',
-            name: 'preview',
-            icon: () => '👁️',
-            onHandle: (params) => {
-              const documentId = params.draft?._id || params.published?._id
-              if (!documentId) {
-                alert('Document ID not found')
-                return
-              }
-              const previewSecret = 'preview-secret-2024'
-              const previewUrl = `https://finishlineathlete.com/preview/${context.schemaType}/${documentId}?secret=${previewSecret}`
-              window.open(previewUrl, '_blank')
-            }
-          }
-        ]
-      }
-      return prev
-    }
-  }
+  // Document actions temporarily disabled due to Sanity 4.9.0 compatibility issues
+  // document: {
+  //   actions: (prev, context) => {
+  //     // Add preview action for content types
+  //     if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
+  //       return [
+  //         ...prev,
+  //         {
+  //           title: 'Preview',
+  //           name: 'preview',
+  //           icon: () => '👁️',
+  //           onHandle: (params) => {
+  //             const documentId = params.draft?._id || params.published?._id
+  //             if (!documentId) {
+  //               alert('Document ID not found')
+  //               return
+  //             }
+  //             const previewSecret = 'preview-secret-2024'
+  //             const previewUrl = `https://finishlineathlete.com/preview/${context.schemaType}/${documentId}?secret=${previewSecret}`
+  //             window.open(previewUrl, '_blank')
+  //           }
+  //         }
+  //       ]
+  //     }
+  //     return prev
+  //   }
+  // }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -15,4 +15,27 @@ export default defineConfig({
   schema: {
     types: schemaTypes,
   },
+
+  document: {
+    actions: (prev, context) => {
+      // Add preview action for content types
+      if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
+        return [
+          ...prev,
+          {
+            title: 'Preview',
+            name: 'preview',
+            icon: () => '👁️',
+            onHandle: () => {
+              const documentId = context.document._id
+              const previewSecret = 'preview-secret-2024' // In production, use environment variable
+              const previewUrl = `https://finishlineathlete.com/preview/${context.schemaType}/${documentId}?secret=${previewSecret}`
+              window.open(previewUrl, '_blank')
+            }
+          }
+        ]
+      }
+      return prev
+    }
+  }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -17,23 +17,23 @@ export default defineConfig({
     types: schemaTypes,
   },
 
-        document: {
-          // Simple preview configuration for content list
-          preview: {
-            select: {
-              title: 'title',
-              subtitle: 'excerpt',
-              media: 'featuredImage'
-            }
-          },
-          
-          // Add preview action
-          actions: (prev, context) => {
-            // Only add preview action for content types
-            if (['shorts', 'longForm'].includes(context.schemaType)) {
-              return [...prev, PreviewAction];
-            }
-            return prev;
-          }
-        }
+  document: {
+    // Simple preview configuration for content list
+    preview: {
+      select: {
+        title: 'title',
+        subtitle: 'excerpt',
+        media: 'featuredImage'
+      }
+    },
+    
+    // Add preview action
+    actions: (prev, context) => {
+      // Only add preview action for content types
+      if (['shorts', 'longForm'].includes(context.schemaType)) {
+        return [...prev, PreviewAction];
+      }
+      return prev;
+    }
+  }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -16,31 +16,22 @@ export default defineConfig({
     types: schemaTypes,
   },
 
-  // Document actions temporarily disabled due to Sanity 4.9.0 compatibility issues
-  // document: {
-  //   actions: (prev, context) => {
-  //     // Add preview action for content types
-  //     if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
-  //       return [
-  //         ...prev,
-  //         {
-  //           title: 'Preview',
-  //           name: 'preview',
-  //           icon: () => '👁️',
-  //           onHandle: (params) => {
-  //             const documentId = params.draft?._id || params.published?._id
-  //             if (!documentId) {
-  //               alert('Document ID not found')
-  //               return
-  //             }
-  //             const previewSecret = 'preview-secret-2024'
-  //             const previewUrl = `https://finishlineathlete.com/preview/${context.schemaType}/${documentId}?secret=${previewSecret}`
-  //             window.open(previewUrl, '_blank')
-  //           }
-  //         }
-  //       ]
-  //     }
-  //     return prev
-  //   }
-  // }
+  document: {
+    // Add preview configuration for content types
+    preview: {
+      select: {
+        title: 'title',
+        subtitle: 'excerpt',
+        media: 'featuredImage'
+      },
+      prepare(selection) {
+        const {title, subtitle, media} = selection
+        return {
+          title: title || 'Untitled',
+          subtitle: subtitle || 'No excerpt',
+          media: media
+        }
+      }
+    }
+  }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -17,20 +17,12 @@ export default defineConfig({
   },
 
   document: {
-    // Add preview configuration for content types
+    // Simple preview configuration for content list
     preview: {
       select: {
         title: 'title',
         subtitle: 'excerpt',
         media: 'featuredImage'
-      },
-      prepare(selection) {
-        const {title, subtitle, media} = selection
-        return {
-          title: title || 'Untitled',
-          subtitle: subtitle || 'No excerpt',
-          media: media
-        }
       }
     }
   }

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -16,14 +16,37 @@ export default defineConfig({
     types: schemaTypes,
   },
 
-  document: {
-    // Simple preview configuration for content list
-    preview: {
-      select: {
-        title: 'title',
-        subtitle: 'excerpt',
-        media: 'featuredImage'
-      }
-    }
-  }
+        document: {
+          // Simple preview configuration for content list
+          preview: {
+            select: {
+              title: 'title',
+              subtitle: 'excerpt',
+              media: 'featuredImage'
+            }
+          },
+          
+          // Add preview action button
+          actions: (prev, context) => {
+            const {schemaType} = context
+            const isContentType = ['shorts', 'longForm'].includes(schemaType)
+            
+            if (!isContentType) return prev
+            
+            return [
+              ...prev,
+              {
+                name: 'preview',
+                title: '👁️ Preview',
+                icon: () => '👁️',
+                onHandle: () => {
+                  const docId = context.documentId
+                  const baseUrl = 'https://finishlineathlete.com/preview'
+                  const previewUrl = `${baseUrl}/${schemaType}/${docId}?secret=preview-secret-2024`
+                  window.open(previewUrl, '_blank')
+                }
+              }
+            ]
+          }
+        }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -29,7 +29,11 @@ export default defineConfig({
           
           // Add preview action
           actions: (prev, context) => {
-            return [...prev, PreviewAction];
+            // Only add preview action for content types
+            if (['shorts', 'longForm'].includes(context.schemaType)) {
+              return [...prev, PreviewAction];
+            }
+            return prev;
           }
         }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -24,29 +24,6 @@ export default defineConfig({
               subtitle: 'excerpt',
               media: 'featuredImage'
             }
-          },
-          
-          // Add preview action button
-          actions: (prev, context) => {
-            const {schemaType} = context
-            const isContentType = ['shorts', 'longForm'].includes(schemaType)
-            
-            if (!isContentType) return prev
-            
-            return [
-              ...prev,
-              {
-                name: 'preview',
-                title: '👁️ Preview',
-                icon: () => '👁️',
-                onHandle: () => {
-                  const docId = context.documentId
-                  const baseUrl = 'https://finishlineathlete.com/preview'
-                  const previewUrl = `${baseUrl}/${schemaType}/${docId}?secret=preview-secret-2024`
-                  window.open(previewUrl, '_blank')
-                }
-              }
-            ]
           }
         }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -2,6 +2,7 @@ import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
 import {schemaTypes} from './schemaTypes'
+import {PreviewAction} from './actions/PreviewAction'
 
 export default defineConfig({
   name: 'default',
@@ -24,6 +25,11 @@ export default defineConfig({
               subtitle: 'excerpt',
               media: 'featuredImage'
             }
+          },
+          
+          // Add preview action
+          actions: (prev, context) => {
+            return [...prev, PreviewAction];
           }
         }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -32,6 +32,42 @@ export default defineConfig({
           media: media
         }
       }
+    },
+    
+    // Add preview action button
+    actions: (prev, context) => {
+      if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
+        return [
+          ...prev,
+          {
+            title: 'Preview',
+            name: 'preview',
+            icon: () => '👁️',
+            onHandle: () => {
+              // Create a preview modal or panel
+              const docId = context.document._id
+              const docTitle = context.document.title || 'Untitled'
+              const docExcerpt = context.document.excerpt || 'No excerpt'
+              const docImage = context.document.featuredImage?.asset?.url || ''
+              
+              // Show preview in a simple alert for now
+              const previewContent = `
+                PREVIEW: ${docTitle}
+                
+                ${docExcerpt}
+                
+                ${docImage ? `Image: ${docImage}` : 'No image'}
+                
+                Document ID: ${docId}
+                Type: ${context.schemaType}
+              `
+              
+              alert(previewContent)
+            }
+          }
+        ]
+      }
+      return prev
     }
   }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -32,42 +32,6 @@ export default defineConfig({
           media: media
         }
       }
-    },
-    
-    // Add preview action button
-    actions: (prev, context) => {
-      if (context.schemaType === 'shorts' || context.schemaType === 'longForm') {
-        return [
-          ...prev,
-          {
-            title: 'Preview',
-            name: 'preview',
-            icon: () => '👁️',
-            onHandle: () => {
-              // Create a preview modal or panel
-              const docId = context.document._id
-              const docTitle = context.document.title || 'Untitled'
-              const docExcerpt = context.document.excerpt || 'No excerpt'
-              const docImage = context.document.featuredImage?.asset?.url || ''
-              
-              // Show preview in a simple alert for now
-              const previewContent = `
-                PREVIEW: ${docTitle}
-                
-                ${docExcerpt}
-                
-                ${docImage ? `Image: ${docImage}` : 'No image'}
-                
-                Document ID: ${docId}
-                Type: ${context.schemaType}
-              `
-              
-              alert(previewContent)
-            }
-          }
-        ]
-      }
-      return prev
     }
   }
 })

--- a/sanity.config.js
+++ b/sanity.config.js
@@ -26,9 +26,13 @@ export default defineConfig({
             title: 'Preview',
             name: 'preview',
             icon: () => '👁️',
-            onHandle: () => {
-              const documentId = context.document._id
-              const previewSecret = 'preview-secret-2024' // In production, use environment variable
+            onHandle: (params) => {
+              const documentId = params.draft?._id || params.published?._id
+              if (!documentId) {
+                alert('Document ID not found')
+                return
+              }
+              const previewSecret = 'preview-secret-2024'
               const previewUrl = `https://finishlineathlete.com/preview/${context.schemaType}/${documentId}?secret=${previewSecret}`
               window.open(previewUrl, '_blank')
             }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -182,12 +182,57 @@ export default {
       type: 'string',
       readOnly: true,
       description: 'Click the link below to preview this content before publishing',
-      initialValue: (doc, context) => {
-        const docId = doc?._id || context?.document?._id
-        if (docId) {
-          return `https://finishlineathlete.com/preview/longForm/${docId}?secret=preview-secret-2024`
+      components: {
+        input: (props) => {
+          const docId = props.document?._id
+          const previewUrl = docId 
+            ? `https://finishlineathlete.com/preview/longForm/${docId}?secret=preview-secret-2024`
+            : 'Preview URL will appear when document is loaded'
+          
+          return (
+            <div style={{ 
+              padding: '12px', 
+              border: '1px solid #e1e5e9', 
+              borderRadius: '6px', 
+              backgroundColor: '#f8f9fa',
+              fontFamily: 'system-ui, sans-serif'
+            }}>
+              <div style={{ 
+                marginBottom: '8px', 
+                fontWeight: '600', 
+                color: '#1a1a1a',
+                fontSize: '14px'
+              }}>
+                Preview URL:
+              </div>
+              <div style={{ 
+                marginBottom: '8px',
+                wordBreak: 'break-all',
+                fontSize: '13px'
+              }}>
+                <a 
+                  href={previewUrl} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  style={{ 
+                    color: '#0066cc', 
+                    textDecoration: 'underline',
+                    cursor: 'pointer'
+                  }}
+                >
+                  {previewUrl}
+                </a>
+              </div>
+              <div style={{ 
+                fontSize: '12px', 
+                color: '#6b7280',
+                fontStyle: 'italic'
+              }}>
+                Click the link above to preview this content
+              </div>
+            </div>
+          )
         }
-        return ''
       }
     }
   ]

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -181,59 +181,8 @@ export default {
       title: '👁️ Preview Content',
       type: 'string',
       readOnly: true,
-      description: 'Click the link below to preview this content before publishing',
-      components: {
-        input: (props) => {
-          const docId = props.document?._id
-          const previewUrl = docId 
-            ? `https://finishlineathlete.com/preview/longForm/${docId}?secret=preview-secret-2024`
-            : 'Preview URL will appear when document is loaded'
-          
-          return (
-            <div style={{ 
-              padding: '12px', 
-              border: '1px solid #e1e5e9', 
-              borderRadius: '6px', 
-              backgroundColor: '#f8f9fa',
-              fontFamily: 'system-ui, sans-serif'
-            }}>
-              <div style={{ 
-                marginBottom: '8px', 
-                fontWeight: '600', 
-                color: '#1a1a1a',
-                fontSize: '14px'
-              }}>
-                Preview URL:
-              </div>
-              <div style={{ 
-                marginBottom: '8px',
-                wordBreak: 'break-all',
-                fontSize: '13px'
-              }}>
-                <a 
-                  href={previewUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  style={{ 
-                    color: '#0066cc', 
-                    textDecoration: 'underline',
-                    cursor: 'pointer'
-                  }}
-                >
-                  {previewUrl}
-                </a>
-              </div>
-              <div style={{ 
-                fontSize: '12px', 
-                color: '#6b7280',
-                fontStyle: 'italic'
-              }}>
-                Click the link above to preview this content
-              </div>
-            </div>
-          )
-        }
-      }
+      description: 'Preview URL for this content (copy and paste into browser)',
+      placeholder: 'Preview URL will be generated automatically'
     }
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -179,18 +179,16 @@ export default {
     {
       name: 'previewUrl',
       title: '👁️ Preview Content',
-      type: 'url',
+      type: 'string',
       readOnly: true,
       description: 'Click the link below to preview this content before publishing',
-      initialValue: (doc) => {
-        if (doc._id) {
-          return `https://finishlineathlete.com/preview/longForm/${doc._id}?secret=preview-secret-2024`
+      initialValue: (doc, context) => {
+        const docId = doc?._id || context?.document?._id
+        if (docId) {
+          return `https://finishlineathlete.com/preview/longForm/${docId}?secret=preview-secret-2024`
         }
         return ''
-      },
-      validation: Rule => Rule.uri({
-        scheme: ['http', 'https']
-      })
+      }
     }
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,14 +175,5 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview Field
-    {
-      name: 'previewUrl',
-      title: '👁️ Preview Content',
-      type: 'string',
-      readOnly: true,
-      description: 'Preview URL for this content (copy and paste into browser)',
-      placeholder: 'Preview URL will be generated automatically'
-    }
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,14 +175,23 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview Field
+    // Debug Test Field
+    {
+      name: 'debugTest',
+      title: '🔍 Debug Test',
+      type: 'text',
+      readOnly: true,
+      description: 'This field helps us debug what\'s happening',
+      initialValue: 'DEBUG: This should appear for new documents'
+    },
+    
+    // Simple Preview Field
     {
       name: 'preview',
       title: '👁️ Content Preview',
       type: 'text',
       readOnly: true,
-      description: 'Preview your content by looking at the fields above',
-      initialValue: 'To preview your content:\n\n1. Check the Title field above\n2. Check the Excerpt field above\n3. Check the Featured Image field above\n4. All fields together show how your content will appear\n\nThis gives you a complete preview of your article!'
+      description: 'Preview your content by looking at the fields above'
     }
 
   ]

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,19 +175,6 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview URL - computed field
-    {
-      name: 'previewUrl',
-      title: '👁️ Preview URL',
-      type: 'string',
-      readOnly: true,
-      description: 'Click to copy and open in new tab',
-      fieldset: 'seoPhase1',
-      initialValue: (_, {document}) => {
-        if (!document?._id) return 'Save document to generate preview URL'
-        return `https://finishlineathlete.com/preview/longForm/${document._id}?secret=preview-secret-2024`
-      }
-    },
     
 
   ]

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,14 +175,26 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
+    // Preview URL
+    {
+      name: 'previewUrl',
+      title: '👁️ Preview URL',
+      type: 'url',
+      readOnly: true,
+      description: 'Copy this URL to preview your content on the website',
+      validation: Rule => Rule.uri({
+        scheme: ['http', 'https']
+      })
+    },
+    
     // Preview Instructions
     {
       name: 'previewInstructions',
-      title: '👁️ How to Preview',
+      title: '📋 Preview Instructions',
       type: 'text',
       readOnly: true,
-      description: 'Instructions for previewing your content',
-      initialValue: 'To preview this content:\n\n1. Copy the Document ID from the URL above\n2. Go to: https://finishlineathlete.com/preview/longForm/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/longForm/abc123?secret=preview-secret-2024'
+      description: 'How to preview your content',
+      initialValue: 'To preview this content:\n\n1. Look at the "Preview URL" field above\n2. If it\'s empty, manually construct the URL:\n   https://finishlineathlete.com/preview/longForm/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with: 47607f43-c555-46f7-bcaf-50b570a216fe\n4. Open the URL in your browser\n\nFor this article, the preview URL is:\nhttps://finishlineathlete.com/preview/longForm/47607f43-c555-46f7-bcaf-50b570a216fe?secret=preview-secret-2024'
     }
 
   ]

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -178,16 +178,19 @@ export default {
     // Preview Field
     {
       name: 'previewUrl',
-      title: 'Preview URL',
+      title: '👁️ Preview Content',
       type: 'url',
       readOnly: true,
-      description: 'Click to preview this content before publishing',
+      description: 'Click the link below to preview this content before publishing',
       initialValue: (doc) => {
         if (doc._id) {
           return `https://finishlineathlete.com/preview/longForm/${doc._id}?secret=preview-secret-2024`
         }
         return ''
-      }
+      },
+      validation: Rule => Rule.uri({
+        scheme: ['http', 'https']
+      })
     }
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -181,26 +181,8 @@ export default {
       title: '👁️ Content Preview',
       type: 'text',
       readOnly: true,
-      description: 'This shows how your content will appear',
-      initialValue: (doc, context) => {
-        const title = doc?.title || 'Untitled'
-        const excerpt = doc?.excerpt || 'No excerpt provided'
-        const author = doc?.author?.name || 'Unknown Author'
-        const publishDate = doc?.publishDate ? new Date(doc.publishDate).toLocaleDateString() : 'Not set'
-        const readingTime = doc?.readingTime || 0
-        const wordCount = doc?.wordCount || 0
-        
-        return `📰 ${title}
-        
-📝 ${excerpt}
-
-👤 By ${author}
-📅 ${publishDate}
-⏱️ ${readingTime} min read
-📊 ${wordCount} words
-
-This is how your content will appear to readers.`
-      }
+      description: 'Preview your content by looking at the fields above',
+      initialValue: 'To preview your content:\n\n1. Check the Title field above\n2. Check the Excerpt field above\n3. Check the Featured Image field above\n4. All fields together show how your content will appear\n\nThis gives you a complete preview of your article!'
     }
 
   ]

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,5 +175,33 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
+    // Preview Field
+    {
+      name: 'preview',
+      title: '👁️ Content Preview',
+      type: 'text',
+      readOnly: true,
+      description: 'This shows how your content will appear',
+      initialValue: (doc, context) => {
+        const title = doc?.title || 'Untitled'
+        const excerpt = doc?.excerpt || 'No excerpt provided'
+        const author = doc?.author?.name || 'Unknown Author'
+        const publishDate = doc?.publishDate ? new Date(doc.publishDate).toLocaleDateString() : 'Not set'
+        const readingTime = doc?.readingTime || 0
+        const wordCount = doc?.wordCount || 0
+        
+        return `📰 ${title}
+        
+📝 ${excerpt}
+
+👤 By ${author}
+📅 ${publishDate}
+⏱️ ${readingTime} min read
+📊 ${wordCount} words
+
+This is how your content will appear to readers.`
+      }
+    }
+
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,16 +175,18 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview URL
+    // Preview URL - computed field
     {
       name: 'previewUrl',
       title: '👁️ Preview URL',
-      type: 'url',
+      type: 'string',
       readOnly: true,
-      description: 'Copy this URL to preview your content on the website',
-      validation: Rule => Rule.uri({
-        scheme: ['http', 'https']
-      })
+      description: 'Click to copy and open in new tab',
+      fieldset: 'seoPhase1',
+      initialValue: (_, {document}) => {
+        if (!document?._id) return 'Save document to generate preview URL'
+        return `https://finishlineathlete.com/preview/longForm/${document._id}?secret=preview-secret-2024`
+      }
     },
     
 

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -173,6 +173,21 @@ export default {
       type: 'datetime',
       fieldset: 'seoPhase1',
       validation: Rule => Rule.required().error('Last Updated Date is required')
+    },
+
+    // Preview Field
+    {
+      name: 'previewUrl',
+      title: 'Preview URL',
+      type: 'url',
+      readOnly: true,
+      description: 'Click to preview this content before publishing',
+      initialValue: (doc) => {
+        if (doc._id) {
+          return `https://finishlineathlete.com/preview/longForm/${doc._id}?secret=preview-secret-2024`
+        }
+        return ''
+      }
     }
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -187,15 +187,6 @@ export default {
       })
     },
     
-    // Preview Instructions
-    {
-      name: 'previewInstructions',
-      title: '📋 Preview Instructions',
-      type: 'text',
-      readOnly: true,
-      description: 'How to preview your content',
-      initialValue: 'To preview this content:\n\n1. Look at the "Preview URL" field above\n2. If it\'s empty, manually construct the URL:\n   https://finishlineathlete.com/preview/longForm/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with: 47607f43-c555-46f7-bcaf-50b570a216fe\n4. Open the URL in your browser\n\nFor this article, the preview URL is:\nhttps://finishlineathlete.com/preview/longForm/47607f43-c555-46f7-bcaf-50b570a216fe?secret=preview-secret-2024'
-    }
 
   ]
 }

--- a/schemaTypes/longForm.js
+++ b/schemaTypes/longForm.js
@@ -175,23 +175,14 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Debug Test Field
+    // Preview Instructions
     {
-      name: 'debugTest',
-      title: '🔍 Debug Test',
+      name: 'previewInstructions',
+      title: '👁️ How to Preview',
       type: 'text',
       readOnly: true,
-      description: 'This field helps us debug what\'s happening',
-      initialValue: 'DEBUG: This should appear for new documents'
-    },
-    
-    // Simple Preview Field
-    {
-      name: 'preview',
-      title: '👁️ Content Preview',
-      type: 'text',
-      readOnly: true,
-      description: 'Preview your content by looking at the fields above'
+      description: 'Instructions for previewing your content',
+      initialValue: 'To preview this content:\n\n1. Copy the Document ID from the URL above\n2. Go to: https://finishlineathlete.com/preview/longForm/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/longForm/abc123?secret=preview-secret-2024'
     }
 
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -177,9 +177,41 @@ export default {
       readOnly: true,
       description: 'Click to copy and open in new tab',
       fieldset: 'seoPhase1',
-      initialValue: (_, {document}) => {
-        if (!document?._id) return 'Save document to generate preview URL'
-        return `https://finishlineathlete.com/preview/shorts/${document._id}?secret=preview-secret-2024`
+      components: {
+        input: (props) => {
+          const {value, onChange} = props
+          const documentId = props.document?._id || 'DOCUMENT_ID'
+          const previewUrl = `https://finishlineathlete.com/preview/shorts/${documentId}?secret=preview-secret-2024`
+          
+          // Update the value if it's different
+          if (value !== previewUrl) {
+            onChange(previewUrl)
+          }
+          
+          return (
+            <div style={{padding: '8px', backgroundColor: '#f5f5f5', borderRadius: '4px', fontFamily: 'monospace', fontSize: '12px'}}>
+              <div style={{marginBottom: '8px', fontWeight: 'bold'}}>Preview URL:</div>
+              <div style={{wordBreak: 'break-all', marginBottom: '8px'}}>{previewUrl}</div>
+              <button 
+                onClick={() => {
+                  navigator.clipboard.writeText(previewUrl)
+                  alert('Preview URL copied to clipboard!')
+                }}
+                style={{
+                  padding: '4px 8px',
+                  backgroundColor: '#0070f3',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '12px'
+                }}
+              >
+                Copy URL
+              </button>
+            </div>
+          )
+        }
       }
     },
     

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -181,15 +181,6 @@ export default {
       })
     },
     
-    // Preview Instructions
-    {
-      name: 'previewInstructions',
-      title: '📋 Preview Instructions',
-      type: 'text',
-      readOnly: true,
-      description: 'How to preview your content',
-      initialValue: 'To preview this content:\n\n1. Look at the "Preview URL" field above\n2. If it\'s empty, manually construct the URL:\n   https://finishlineathlete.com/preview/shorts/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual document ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/shorts/abc123?secret=preview-secret-2024'
-    }
 
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -172,16 +172,19 @@ export default {
     // Preview Field
     {
       name: 'previewUrl',
-      title: 'Preview URL',
+      title: '👁️ Preview Content',
       type: 'url',
       readOnly: true,
-      description: 'Click to preview this content before publishing',
+      description: 'Click the link below to preview this content before publishing',
       initialValue: (doc) => {
         if (doc._id) {
           return `https://finishlineathlete.com/preview/shorts/${doc._id}?secret=preview-secret-2024`
         }
         return ''
-      }
+      },
+      validation: Rule => Rule.uri({
+        scheme: ['http', 'https']
+      })
     }
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -175,26 +175,8 @@ export default {
       title: '👁️ Content Preview',
       type: 'text',
       readOnly: true,
-      description: 'This shows how your content will appear',
-      initialValue: (doc, context) => {
-        const title = doc?.title || 'Untitled'
-        const excerpt = doc?.excerpt || 'No excerpt provided'
-        const author = doc?.author?.name || 'Unknown Author'
-        const publishDate = doc?.publishDate ? new Date(doc.publishDate).toLocaleDateString() : 'Not set'
-        const readingTime = doc?.readingTime || 0
-        const wordCount = doc?.wordCount || 0
-        
-        return `📰 ${title}
-        
-📝 ${excerpt}
-
-👤 By ${author}
-📅 ${publishDate}
-⏱️ ${readingTime} min read
-📊 ${wordCount} words
-
-This is how your content will appear to readers.`
-      }
+      description: 'Preview your content by looking at the fields above',
+      initialValue: 'To preview your content:\n\n1. Check the Title field above\n2. Check the Excerpt field above\n3. Check the Featured Image field above\n4. All fields together show how your content will appear\n\nThis gives you a complete preview of your article!'
     }
 
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -176,12 +176,57 @@ export default {
       type: 'string',
       readOnly: true,
       description: 'Click the link below to preview this content before publishing',
-      initialValue: (doc, context) => {
-        const docId = doc?._id || context?.document?._id
-        if (docId) {
-          return `https://finishlineathlete.com/preview/shorts/${docId}?secret=preview-secret-2024`
+      components: {
+        input: (props) => {
+          const docId = props.document?._id
+          const previewUrl = docId 
+            ? `https://finishlineathlete.com/preview/shorts/${docId}?secret=preview-secret-2024`
+            : 'Preview URL will appear when document is loaded'
+          
+          return (
+            <div style={{ 
+              padding: '12px', 
+              border: '1px solid #e1e5e9', 
+              borderRadius: '6px', 
+              backgroundColor: '#f8f9fa',
+              fontFamily: 'system-ui, sans-serif'
+            }}>
+              <div style={{ 
+                marginBottom: '8px', 
+                fontWeight: '600', 
+                color: '#1a1a1a',
+                fontSize: '14px'
+              }}>
+                Preview URL:
+              </div>
+              <div style={{ 
+                marginBottom: '8px',
+                wordBreak: 'break-all',
+                fontSize: '13px'
+              }}>
+                <a 
+                  href={previewUrl} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  style={{ 
+                    color: '#0066cc', 
+                    textDecoration: 'underline',
+                    cursor: 'pointer'
+                  }}
+                >
+                  {previewUrl}
+                </a>
+              </div>
+              <div style={{ 
+                fontSize: '12px', 
+                color: '#6b7280',
+                fontStyle: 'italic'
+              }}>
+                Click the link above to preview this content
+              </div>
+            </div>
+          )
         }
-        return ''
       }
     }
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -173,18 +173,16 @@ export default {
     {
       name: 'previewUrl',
       title: '👁️ Preview Content',
-      type: 'url',
+      type: 'string',
       readOnly: true,
       description: 'Click the link below to preview this content before publishing',
-      initialValue: (doc) => {
-        if (doc._id) {
-          return `https://finishlineathlete.com/preview/shorts/${doc._id}?secret=preview-secret-2024`
+      initialValue: (doc, context) => {
+        const docId = doc?._id || context?.document?._id
+        if (docId) {
+          return `https://finishlineathlete.com/preview/shorts/${docId}?secret=preview-secret-2024`
         }
         return ''
-      },
-      validation: Rule => Rule.uri({
-        scheme: ['http', 'https']
-      })
+      }
     }
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -175,59 +175,8 @@ export default {
       title: '👁️ Preview Content',
       type: 'string',
       readOnly: true,
-      description: 'Click the link below to preview this content before publishing',
-      components: {
-        input: (props) => {
-          const docId = props.document?._id
-          const previewUrl = docId 
-            ? `https://finishlineathlete.com/preview/shorts/${docId}?secret=preview-secret-2024`
-            : 'Preview URL will appear when document is loaded'
-          
-          return (
-            <div style={{ 
-              padding: '12px', 
-              border: '1px solid #e1e5e9', 
-              borderRadius: '6px', 
-              backgroundColor: '#f8f9fa',
-              fontFamily: 'system-ui, sans-serif'
-            }}>
-              <div style={{ 
-                marginBottom: '8px', 
-                fontWeight: '600', 
-                color: '#1a1a1a',
-                fontSize: '14px'
-              }}>
-                Preview URL:
-              </div>
-              <div style={{ 
-                marginBottom: '8px',
-                wordBreak: 'break-all',
-                fontSize: '13px'
-              }}>
-                <a 
-                  href={previewUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  style={{ 
-                    color: '#0066cc', 
-                    textDecoration: 'underline',
-                    cursor: 'pointer'
-                  }}
-                >
-                  {previewUrl}
-                </a>
-              </div>
-              <div style={{ 
-                fontSize: '12px', 
-                color: '#6b7280',
-                fontStyle: 'italic'
-              }}>
-                Click the link above to preview this content
-              </div>
-            </div>
-          )
-        }
-      }
+      description: 'Preview URL for this content (copy and paste into browser)',
+      placeholder: 'Preview URL will be generated automatically'
     }
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,14 +169,26 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
+    // Preview URL
+    {
+      name: 'previewUrl',
+      title: '👁️ Preview URL',
+      type: 'url',
+      readOnly: true,
+      description: 'Copy this URL to preview your content on the website',
+      validation: Rule => Rule.uri({
+        scheme: ['http', 'https']
+      })
+    },
+    
     // Preview Instructions
     {
       name: 'previewInstructions',
-      title: '👁️ How to Preview',
+      title: '📋 Preview Instructions',
       type: 'text',
       readOnly: true,
-      description: 'Instructions for previewing your content',
-      initialValue: 'To preview this content:\n\n1. Copy the Document ID from the URL above\n2. Go to: https://finishlineathlete.com/preview/shorts/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/shorts/abc123?secret=preview-secret-2024'
+      description: 'How to preview your content',
+      initialValue: 'To preview this content:\n\n1. Look at the "Preview URL" field above\n2. If it\'s empty, manually construct the URL:\n   https://finishlineathlete.com/preview/shorts/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual document ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/shorts/abc123?secret=preview-secret-2024'
     }
 
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,5 +169,33 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
+    // Preview Field
+    {
+      name: 'preview',
+      title: '👁️ Content Preview',
+      type: 'text',
+      readOnly: true,
+      description: 'This shows how your content will appear',
+      initialValue: (doc, context) => {
+        const title = doc?.title || 'Untitled'
+        const excerpt = doc?.excerpt || 'No excerpt provided'
+        const author = doc?.author?.name || 'Unknown Author'
+        const publishDate = doc?.publishDate ? new Date(doc.publishDate).toLocaleDateString() : 'Not set'
+        const readingTime = doc?.readingTime || 0
+        const wordCount = doc?.wordCount || 0
+        
+        return `📰 ${title}
+        
+📝 ${excerpt}
+
+👤 By ${author}
+📅 ${publishDate}
+⏱️ ${readingTime} min read
+📊 ${wordCount} words
+
+This is how your content will appear to readers.`
+      }
+    }
+
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,23 +169,14 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Debug Test Field
+    // Preview Instructions
     {
-      name: 'debugTest',
-      title: '🔍 Debug Test',
+      name: 'previewInstructions',
+      title: '👁️ How to Preview',
       type: 'text',
       readOnly: true,
-      description: 'This field helps us debug what\'s happening',
-      initialValue: 'DEBUG: This should appear for new documents'
-    },
-    
-    // Simple Preview Field
-    {
-      name: 'preview',
-      title: '👁️ Content Preview',
-      type: 'text',
-      readOnly: true,
-      description: 'Preview your content by looking at the fields above'
+      description: 'Instructions for previewing your content',
+      initialValue: 'To preview this content:\n\n1. Copy the Document ID from the URL above\n2. Go to: https://finishlineathlete.com/preview/shorts/[DOCUMENT_ID]?secret=preview-secret-2024\n3. Replace [DOCUMENT_ID] with the actual ID\n4. Open the URL in your browser\n\nExample: https://finishlineathlete.com/preview/shorts/abc123?secret=preview-secret-2024'
     }
 
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,51 +169,6 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview URL - computed field
-    {
-      name: 'previewUrl',
-      title: '👁️ Preview URL',
-      type: 'string',
-      readOnly: true,
-      description: 'Click to copy and open in new tab',
-      fieldset: 'seoPhase1',
-      components: {
-        input: (props) => {
-          const {value, onChange} = props
-          const documentId = props.document?._id || 'DOCUMENT_ID'
-          const previewUrl = `https://finishlineathlete.com/preview/shorts/${documentId}?secret=preview-secret-2024`
-          
-          // Update the value if it's different
-          if (value !== previewUrl) {
-            onChange(previewUrl)
-          }
-          
-          return (
-            <div style={{padding: '8px', backgroundColor: '#f5f5f5', borderRadius: '4px', fontFamily: 'monospace', fontSize: '12px'}}>
-              <div style={{marginBottom: '8px', fontWeight: 'bold'}}>Preview URL:</div>
-              <div style={{wordBreak: 'break-all', marginBottom: '8px'}}>{previewUrl}</div>
-              <button 
-                onClick={() => {
-                  navigator.clipboard.writeText(previewUrl)
-                  alert('Preview URL copied to clipboard!')
-                }}
-                style={{
-                  padding: '4px 8px',
-                  backgroundColor: '#0070f3',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer',
-                  fontSize: '12px'
-                }}
-              >
-                Copy URL
-              </button>
-            </div>
-          )
-        }
-      }
-    },
     
 
   ]

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -167,6 +167,21 @@ export default {
       type: 'datetime',
       fieldset: 'seoPhase1',
       validation: Rule => Rule.required().error('Last Updated Date is required')
+    },
+
+    // Preview Field
+    {
+      name: 'previewUrl',
+      title: 'Preview URL',
+      type: 'url',
+      readOnly: true,
+      description: 'Click to preview this content before publishing',
+      initialValue: (doc) => {
+        if (doc._id) {
+          return `https://finishlineathlete.com/preview/shorts/${doc._id}?secret=preview-secret-2024`
+        }
+        return ''
+      }
     }
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,16 +169,18 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview URL
+    // Preview URL - computed field
     {
       name: 'previewUrl',
       title: '👁️ Preview URL',
-      type: 'url',
+      type: 'string',
       readOnly: true,
-      description: 'Copy this URL to preview your content on the website',
-      validation: Rule => Rule.uri({
-        scheme: ['http', 'https']
-      })
+      description: 'Click to copy and open in new tab',
+      fieldset: 'seoPhase1',
+      initialValue: (_, {document}) => {
+        if (!document?._id) return 'Save document to generate preview URL'
+        return `https://finishlineathlete.com/preview/shorts/${document._id}?secret=preview-secret-2024`
+      }
     },
     
 

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,14 +169,5 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview Field
-    {
-      name: 'previewUrl',
-      title: '👁️ Preview Content',
-      type: 'string',
-      readOnly: true,
-      description: 'Preview URL for this content (copy and paste into browser)',
-      placeholder: 'Preview URL will be generated automatically'
-    }
   ]
 }

--- a/schemaTypes/shorts.js
+++ b/schemaTypes/shorts.js
@@ -169,14 +169,23 @@ export default {
       validation: Rule => Rule.required().error('Last Updated Date is required')
     },
 
-    // Preview Field
+    // Debug Test Field
+    {
+      name: 'debugTest',
+      title: '🔍 Debug Test',
+      type: 'text',
+      readOnly: true,
+      description: 'This field helps us debug what\'s happening',
+      initialValue: 'DEBUG: This should appear for new documents'
+    },
+    
+    // Simple Preview Field
     {
       name: 'preview',
       title: '👁️ Content Preview',
       type: 'text',
       readOnly: true,
-      description: 'Preview your content by looking at the fields above',
-      initialValue: 'To preview your content:\n\n1. Check the Title field above\n2. Check the Excerpt field above\n3. Check the Featured Image field above\n4. All fields together show how your content will appear\n\nThis gives you a complete preview of your article!'
+      description: 'Preview your content by looking at the fields above'
     }
 
   ]


### PR DESCRIPTION
Add Sanity Studio preview button and provide frontend preview templates to enable content creators to visualize content before publishing.

This PR enables content creators to see how their `shorts` and `longForm` articles will appear on `finishlineathlete.com` before they are published, improving content quality and reducing errors. It includes the Sanity Studio configuration for the preview button and comprehensive frontend examples to integrate the preview page.

---
<a href="https://cursor.com/background-agent?bcId=bc-cca8aaf2-e13a-4083-8303-0a80897218b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cca8aaf2-e13a-4083-8303-0a80897218b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

